### PR TITLE
Externally functions the same, but an internal refactor:

### DIFF
--- a/Compensable.Tests/ReadmeExamples/PracticalExample.cs
+++ b/Compensable.Tests/ReadmeExamples/PracticalExample.cs
@@ -2,10 +2,10 @@
 
 internal class PracticalExample
 {
-    private IAccountServiceRepository? _accountServiceRepository;
+    private IAccountServiceRepository? _accountServiceRepository = null;
+    private IEmailPlatform? _emailPlatform = null;
 
-    private IEmailPlatform? _emailPlatform;
-
+    #pragma warning disable CS8602
     public async Task CreateEmailAsync(
         Guid accountId,
         string domainName,
@@ -47,6 +47,7 @@ internal class PracticalExample
         await compensator.ForeachAsync(adminAliasAddresses,
             async (adminAliasAddress) => await _emailPlatform.CreateAliasAsync(emailServiceId, adminMailboxAddress, adminAliasAddress));
     }
+    #pragma warning restore CS8602
 
     private interface IAccountServiceRepository
     {

--- a/Compensable.Tests/ReadmeExamples/Steps.cs
+++ b/Compensable.Tests/ReadmeExamples/Steps.cs
@@ -2,8 +2,9 @@
 
 internal class Steps
 {
-    private Compensator compensator;
+    private Compensator? compensator = null;
 
+    #pragma warning disable CS8602
     internal async Task AddCompensationAsync(bool compensate)
     {
         await compensator.AddCompensationAsync(
@@ -75,4 +76,5 @@ internal class Steps
         Task compensateStepAsync(int result) => Task.CompletedTask;
         Task<int> stepAsync() => Task.FromResult(1);
     }
+    #pragma warning restore CS8602
 }

--- a/Compensable.Tests/ReadmeExamples/Tags.cs
+++ b/Compensable.Tests/ReadmeExamples/Tags.cs
@@ -32,6 +32,4 @@ internal class Tags
     private Task step1Async() => Task.CompletedTask;
 
     private Task step2Async() => Task.CompletedTask;
-
-    private Task step3Async() => Task.CompletedTask;
 }

--- a/Compensable/Compensable.csproj
+++ b/Compensable/Compensable.csproj
@@ -9,7 +9,7 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageTags>compensable;compensate;rollback;roll back;netstandard2</PackageTags>
 	    <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Version>0.2.4-beta-2</Version>
+        <Version>0.3.0-beta-3</Version>
     </PropertyGroup>
 
 	<ItemGroup>

--- a/Compensable/Compensator.Commit.cs
+++ b/Compensable/Compensator.Commit.cs
@@ -1,39 +1,10 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Compensable
 {
     partial class Compensator
     {
         public async Task CommitAsync()
-        {
-            VerifyCanExecute();
-
-            try
-            {
-                await _executionLock.WaitAsync(_cancellationToken).ConfigureAwait(false);
-
-                try
-                {
-                    VerifyCanExecute();
-
-                    ClearCompensations();
-                }
-                catch
-                {
-                    await SetStatusAsync(CompensatorStatus.FailedToExecute).ConfigureAwait(false);
-                    throw;
-                }
-                finally
-                {
-                    _executionLock.Release();
-                }
-            }
-            catch (Exception whileExecuting)
-            {
-                await CompensateAsync(whileExecuting).ConfigureAwait(false);
-                throw;
-            }
-        }
+            => await ExecuteAsync(ClearStack).ConfigureAwait(false);
     }
 }

--- a/Compensable/Compensator.Compensate.cs
+++ b/Compensable/Compensator.Compensate.cs
@@ -1,9 +1,75 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Compensable
 {
     partial class Compensator
     {
-        public async Task CompensateAsync() => await CompensateAsync(null).ConfigureAwait(false);
+        public async Task CompensateAsync()
+            => await CompensateAsync(null).ConfigureAwait(false);
+
+        private async Task CompensateAsync(Exception whileExecuting)
+        {
+            // short-circuit if compensated / failed to compensate
+            if (Status == CompensatorStatus.Compensated)
+                return;
+
+            if (Status == CompensatorStatus.FailedToCompensate)
+                throw new CompensatorStatusException(CompensatorStatus.FailedToCompensate);
+
+            // acquire compensation lock, ignore cancellation token on compensation
+            await _compensationLock.WaitAsync().ConfigureAwait(false);
+
+            try
+            {
+                // short-circuit if compensated / failed to compensate
+                if (Status == CompensatorStatus.Compensated)
+                    return;
+
+                if (Status == CompensatorStatus.FailedToCompensate)
+                    throw new CompensatorStatusException(CompensatorStatus.FailedToCompensate);
+
+                // set status
+                await SetStatusAsync(CompensatorStatus.Compensating).ConfigureAwait(false);
+
+                // acquire execution lock, i.e. make sure nothing is still executing, ignore cancellation token on compensation
+                await _executionLock.WaitAsync().ConfigureAwait(false);
+
+                // compensate compensation tags
+                while (_taggedCompensations.TryPeek(out var taggedCompensations))
+                {
+                    while (taggedCompensations.Compensations.TryPeek(out var compensateAsync))
+                    {
+                        // execute compensation
+                        await compensateAsync().ConfigureAwait(false);
+
+                        // remove compensation
+                        taggedCompensations.Compensations.TryPop(out _);
+                    }
+
+                    // removed tagged compensation
+                    _taggedCompensations.TryPop(out _);
+                }
+
+                // set status
+                await SetStatusAsync(CompensatorStatus.Compensated).ConfigureAwait(false);
+            }
+            catch (Exception whileCompensating)
+            {
+                // set status
+                await SetStatusAsync(CompensatorStatus.FailedToCompensate).ConfigureAwait(false);
+
+                // throw compensation exception
+                throw new CompensationException(
+                    whileCompensating: whileCompensating,
+                    whileExecuting: whileExecuting);
+            }
+            finally
+            {
+                // release locks
+                _executionLock.Release();
+                _compensationLock.Release();
+            }
+        }
     }
 }

--- a/Compensable/Compensator.CreateTag.cs
+++ b/Compensable/Compensator.CreateTag.cs
@@ -1,44 +1,13 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace Compensable
 {
     partial class Compensator
     {
-        internal async Task<Tag> CreateTagAsync(string label)
-        {
-            VerifyCanExecute();
-
-            try
-            {
-                await _executionLock.WaitAsync(_cancellationToken).ConfigureAwait(false);
-
-                try
-                {
-                    VerifyCanExecute();
-
-                    return AddTagToStack(new Tag(label));
-                }
-                catch
-                {
-                    await SetStatusAsync(CompensatorStatus.FailedToExecute).ConfigureAwait(false);
-                    throw;
-                }
-                finally
-                {
-                    _executionLock.Release();
-                }
-            }
-            catch (Exception whileExecuting)
-            {
-                await CompensateAsync(whileExecuting).ConfigureAwait(false);
-                throw;
-            }
-        }
-
-        #region Parameterless Overload
         public async Task<Tag> CreateTagAsync()
             => await CreateTagAsync(default(string)).ConfigureAwait(false);
-        #endregion
+
+        internal async Task<Tag> CreateTagAsync(string label)
+            => await ExecuteAsync(() => AddTagToStack(new Tag(label))).ConfigureAwait(false);
     }
 }

--- a/Compensable/Compensator.Execute.cs
+++ b/Compensable/Compensator.Execute.cs
@@ -1,0 +1,68 @@
+﻿using System.Threading.Tasks;
+using System;
+
+namespace Compensable
+{
+    partial class Compensator
+    {
+		private async Task ExecuteAsync(Action validation, Func<Task> execution)
+		{
+			VerifyCanExecute();
+
+			try
+			{
+				validation?.Invoke();
+
+				await _executionLock.WaitAsync(_cancellationToken).ConfigureAwait(false);
+
+				try
+				{
+					VerifyCanExecute();
+
+					await execution().ConfigureAwait(false);
+				}
+				catch
+				{
+					await SetStatusAsync(CompensatorStatus.FailedToExecute).ConfigureAwait(false);
+					throw;
+				}
+				finally
+				{
+					_executionLock.Release();
+				}
+			}
+			catch (Exception whileExecuting)
+			{
+				await CompensateAsync(whileExecuting).ConfigureAwait(false);
+				throw;
+			}
+		}
+
+		#region Execution Overloads
+		private async Task ExecuteAsync(Action execution)
+			=> await ExecuteAsync(default(Action), execution.Awaitable()).ConfigureAwait(false);
+        #endregion
+
+        #region Execution -> TResult Overloads
+        private async Task<TResult> ExecuteAsync<TResult>(Func<TResult> execution)
+            => await ExecuteAsync<TResult>(default(Action), execution.Awaitable()).ConfigureAwait(false);
+        #endregion
+
+        #region Validation + Execution Overloads
+        private async Task ExecuteAsync(Action validation, Action execution)
+			=> await ExecuteAsync(validation, execution.Awaitable()).ConfigureAwait(false);
+		#endregion
+
+		#region Validation + Execution -> TResult Overloads
+		private async Task<TResult> ExecuteAsync<TResult>(Action validation, Func<Task<TResult>> execution)
+		{
+			var result = default(TResult);
+			await ExecuteAsync(validation, async () => 
+			{ 
+				result = await execution().ConfigureAwait(false); 
+			}).ConfigureAwait(false);
+			return result;
+		}
+		#endregion
+	}
+}

--- a/Compensable/Compensator.Get.cs
+++ b/Compensable/Compensator.Get.cs
@@ -7,43 +7,21 @@ namespace Compensable
     {
         public async Task<TResult> GetAsync<TResult>(Func<Task<TResult>> execution, Func<TResult, Task> compensation, Tag compensateAtTag)
         {
-            VerifyCanExecute();
-
-            try
-            {
-                if (execution == null)
-                    throw new ArgumentNullException(nameof(execution));
-
-                VerifyTagExists(compensateAtTag);
-
-                await _executionLock.WaitAsync(_cancellationToken).ConfigureAwait(false);
-
-                try
+            return await ExecuteAsync(
+                validation: () =>
                 {
-                    VerifyCanExecute();
-
+                    ValidateExecution(execution);
+                    ValidateTag(compensateAtTag);
+                },
+                execution: async () =>
+                {
                     var result = await execution().ConfigureAwait(false);
 
                     if (compensation != null)
                         AddCompensationToStack(async () => await compensation(result).ConfigureAwait(false), compensateAtTag);
 
                     return result;
-                }
-                catch
-                {
-                    await SetStatusAsync(CompensatorStatus.FailedToExecute).ConfigureAwait(false);
-                    throw;
-                }
-                finally
-                {
-                    _executionLock.Release();
-                }
-            }
-            catch (Exception whileExecuting)
-            {
-                await CompensateAsync(whileExecuting).ConfigureAwait(false);
-                throw;
-            }
+                }).ConfigureAwait(false);
         }
 
         #region Execution Overloads
@@ -56,26 +34,26 @@ namespace Compensable
 
         #region Execution + Compensation Overloads
         public async Task<TResult> GetAsync<TResult>(Func<TResult> execution, Action compensation)
-            => await GetAsync(execution.Awaitable(), compensation.AwaitableIgnore<TResult>(), default(Tag)).ConfigureAwait(false);
+            => await GetAsync(execution.Awaitable(), compensation.AwaitableIgnoreParameter<TResult>(), default(Tag)).ConfigureAwait(false);
 
         public async Task<TResult> GetAsync<TResult>(Func<TResult> execution, Action<TResult> compensation)
             => await GetAsync(execution.Awaitable(), compensation.Awaitable(), default(Tag)).ConfigureAwait(false);
 
         public async Task<TResult> GetAsync<TResult>(Func<TResult> execution, Func<Task> compensation)
-            => await GetAsync(execution.Awaitable(), compensation.Ignore<TResult>(), default(Tag)).ConfigureAwait(false);
+            => await GetAsync(execution.Awaitable(), compensation.IgnoreParameter<TResult>(), default(Tag)).ConfigureAwait(false);
 
         public async Task<TResult> GetAsync<TResult>(Func<TResult> execution, Func<TResult, Task> compensation)
             => await GetAsync(execution.Awaitable(), compensation, default(Tag)).ConfigureAwait(false);
 
 
         public async Task<TResult> GetAsync<TResult>(Func<Task<TResult>> execution, Action compensation)
-            => await GetAsync(execution, compensation.AwaitableIgnore<TResult>(), default(Tag)).ConfigureAwait(false);
+            => await GetAsync(execution, compensation.AwaitableIgnoreParameter<TResult>(), default(Tag)).ConfigureAwait(false);
 
         public async Task<TResult> GetAsync<TResult>(Func<Task<TResult>> execution, Action<TResult> compensation)
             => await GetAsync(execution, compensation.Awaitable(), default(Tag)).ConfigureAwait(false);
 
         public async Task<TResult> GetAsync<TResult>(Func<Task<TResult>> execution, Func<Task> compensation)
-            => await GetAsync(execution, compensation.Ignore<TResult>(), default(Tag)).ConfigureAwait(false);
+            => await GetAsync(execution, compensation.IgnoreParameter<TResult>(), default(Tag)).ConfigureAwait(false);
 
         public async Task<TResult> GetAsync<TResult>(Func<Task<TResult>> execution, Func<TResult, Task> compensation)
             => await GetAsync(execution, compensation, default(Tag)).ConfigureAwait(false);
@@ -83,26 +61,26 @@ namespace Compensable
 
         #region Execution + Compensation + CompensateAtTag Overloads
         public async Task<TResult> GetAsync<TResult>(Func<TResult> execution, Action compensation, Tag tag)
-            => await GetAsync(execution.Awaitable(), compensation.AwaitableIgnore<TResult>(), tag).ConfigureAwait(false);
+            => await GetAsync(execution.Awaitable(), compensation.AwaitableIgnoreParameter<TResult>(), tag).ConfigureAwait(false);
 
         public async Task<TResult> GetAsync<TResult>(Func<TResult> execution, Action<TResult> compensation, Tag tag)
             => await GetAsync(execution.Awaitable(), compensation.Awaitable(), tag).ConfigureAwait(false);
 
         public async Task<TResult> GetAsync<TResult>(Func<TResult> execution, Func<Task> compensation, Tag tag)
-            => await GetAsync(execution.Awaitable(), compensation.Ignore<TResult>(), tag).ConfigureAwait(false);
+            => await GetAsync(execution.Awaitable(), compensation.IgnoreParameter<TResult>(), tag).ConfigureAwait(false);
 
         public async Task<TResult> GetAsync<TResult>(Func<TResult> execution, Func<TResult, Task> compensation, Tag tag)
             => await GetAsync(execution.Awaitable(), compensation, tag).ConfigureAwait(false);
 
 
         public async Task<TResult> GetAsync<TResult>(Func<Task<TResult>> execution, Action compensation, Tag tag)
-            => await GetAsync(execution, compensation.AwaitableIgnore<TResult>(), tag).ConfigureAwait(false);
+            => await GetAsync(execution, compensation.AwaitableIgnoreParameter<TResult>(), tag).ConfigureAwait(false);
 
         public async Task<TResult> GetAsync<TResult>(Func<Task<TResult>> execution, Action<TResult> compensation, Tag tag)
             => await GetAsync(execution, compensation.Awaitable(), tag).ConfigureAwait(false);
 
         public async Task<TResult> GetAsync<TResult>(Func<Task<TResult>> execution, Func<Task> compensation, Tag tag)
-            => await GetAsync(execution, compensation.Ignore<TResult>(), tag).ConfigureAwait(false);
+            => await GetAsync(execution, compensation.IgnoreParameter<TResult>(), tag).ConfigureAwait(false);
         #endregion
     }
 }

--- a/Compensable/Compensator.Validate.cs
+++ b/Compensable/Compensator.Validate.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Compensable
+{
+    partial class Compensator
+    {
+        private void ValidateCompensation(Delegate compensation)
+        {
+            if (compensation == null)
+                throw new ArgumentNullException(nameof(compensation));
+        }
+
+        private void ValidateExecution(Delegate execution)
+        {
+            if (execution == null)
+                throw new ArgumentNullException(nameof(execution));
+        }
+
+        private void ValidateItems<T>(IEnumerable<T> items)
+        { 
+            if (items == null)
+                throw new ArgumentNullException(nameof(items));
+        }
+
+        private void ValidateTag(Tag tag)
+        {
+            if (tag != null && !_taggedCompensations.Any(c => c.Tag == tag))
+                throw new TagNotFoundException();
+        }
+
+        private void ValidateTest(Func<Task<bool>> test)
+        {
+            if (test == null)
+                throw new ArgumentNullException(nameof(test));
+        }
+    }
+}

--- a/Compensable/Compensator.cs
+++ b/Compensable/Compensator.cs
@@ -15,7 +15,7 @@ namespace Compensable
         private readonly SemaphoreSlim _executionLock;
         private readonly SemaphoreSlim _statusLock;
         private readonly ConcurrentStack<(ConcurrentStack<Func<Task>> Compensations, Tag Tag)> _taggedCompensations;
-        
+
         public CompensatorStatus Status { get; private set; }
 
         public Compensator() : this(CancellationToken.None)
@@ -59,74 +59,10 @@ namespace Compensable
             return tag;
         }
 
-        private void ClearCompensations()
+        private void ClearStack()
         {
             // TODO do we need to acquire compensation lock as an additional safeguard?
             _taggedCompensations.Clear();
-        }
-
-        private async Task CompensateAsync(Exception whileExecuting)
-        {
-            // short-circuit if compensated / failed to compensate
-            if (Status == CompensatorStatus.Compensated)
-                return;
-
-            if (Status == CompensatorStatus.FailedToCompensate)
-                throw new CompensatorStatusException(CompensatorStatus.FailedToCompensate);
-
-            // acquire compensation lock, ignore cancellation token on compensation
-            await _compensationLock.WaitAsync().ConfigureAwait(false);
-
-            try
-            {
-                // short-circuit if compensated / failed to compensate
-                if (Status == CompensatorStatus.Compensated)
-                    return;
-
-                if (Status == CompensatorStatus.FailedToCompensate)
-                    throw new CompensatorStatusException(CompensatorStatus.FailedToCompensate);
-
-                // set status
-                await SetStatusAsync(CompensatorStatus.Compensating).ConfigureAwait(false);
-
-                // acquire execution lock, i.e. make sure nothing is still executing, ignore cancellation token on compensation
-                await _executionLock.WaitAsync().ConfigureAwait(false);
-
-                // compensate compensation tags
-                while (_taggedCompensations.TryPeek(out var taggedCompensations))
-                {
-                    while (taggedCompensations.Compensations.TryPeek(out var compensateAsync))
-                    {
-                        // execute compensation
-                        await compensateAsync().ConfigureAwait(false);
-
-                        // remove compensation
-                        taggedCompensations.Compensations.TryPop(out _);
-                    }
-
-                    // removed tagged compensation
-                    _taggedCompensations.TryPop(out _);
-                }
-
-                // set status
-                await SetStatusAsync(CompensatorStatus.Compensated).ConfigureAwait(false);
-            }
-            catch (Exception whileCompensating)
-            {
-                // set status
-                await SetStatusAsync(CompensatorStatus.FailedToCompensate).ConfigureAwait(false);
-
-                // throw compensation exception
-                throw new CompensationException(
-                    whileCompensating: whileCompensating, 
-                    whileExecuting: whileExecuting);
-            }
-            finally
-            {
-                // release locks
-                _executionLock.Release();
-                _compensationLock.Release();
-            }
         }
 
         private async Task SetStatusAsync(CompensatorStatus status)
@@ -153,12 +89,6 @@ namespace Compensable
                 throw new CompensatorStatusException(Status);
 
             _cancellationToken.ThrowIfCancellationRequested();
-        }
-
-        private void VerifyTagExists(Tag tag)
-        {
-            if (tag != null && !_taggedCompensations.Any(c => c.Tag == tag))
-                throw new TagNotFoundException();
         }
     }
 }

--- a/Compensable/Extensions/Extensions.cs
+++ b/Compensable/Extensions/Extensions.cs
@@ -26,14 +26,14 @@ namespace Compensable
                 : () => Task.FromResult(function());
         }
 
-        internal static Func<T1, Task> AwaitableIgnore<T1>(this Action action)
+        internal static Func<T1, Task> AwaitableIgnoreParameter<T1>(this Action action)
         {
             return action == null
                 ? default(Func<T1, Task>)
                 : (T1 t1) => { action(); return Task.CompletedTask; };
         }
 
-        internal static Func<T1, Task> Ignore<T1>(this Func<Task> asyncFunction)
+        internal static Func<T1, Task> IgnoreParameter<T1>(this Func<Task> asyncFunction)
         {
             return asyncFunction == null
                 ? default(Func<T1, Task>)

--- a/Compensable/Tag.cs
+++ b/Compensable/Tag.cs
@@ -4,12 +4,13 @@ namespace Compensable
 {
     public sealed class Tag
     {
-        internal string Label { get; }
+        internal string Label { get; } // TODO remove this?
 
         internal Tag() : this(null)
         {
         }
-        internal Tag(string label)
+
+        internal Tag(string label) // TODO remove this?
         {
             Label = string.IsNullOrWhiteSpace(label)
                 ? Guid.NewGuid().ToString("n")


### PR DESCRIPTION
- Added ExecuteAsync method to handle common execution code 
- Added common validate methods
- Moved private VerifyTagExists to Compensator.Validate.cs and renamed to ValidateTag 
- Moved private CompensateAsync(Exception) to Compensator.Compensate.cs 
- Renamed Extensions.AwaitableIgnore<T1> to AwaitableIgnoreParameter<T1> and Extensions.Ignore<T1> to IgnoreParameter<T1>